### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,5 +1,8 @@
 name: CodeQL Analysis
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/anissaCh13/rectte/security/code-scanning/1](https://github.com/anissaCh13/rectte/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations (e.g., code checkout and analysis), the `contents: read` permission is sufficient. This ensures the workflow can read repository contents without granting unnecessary write access.

The `permissions` block can be added at the root level of the workflow file to apply to all jobs, or within the `analyze` job to limit permissions specifically for that job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
